### PR TITLE
Change repository url

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -17,8 +17,8 @@ email=software@rise-group.org
 tags=Clusterpy,Clustering,RISE Group
 
 homepage=http://www.rise-group.org
-tracker=https://www.github.com/risegroup/clusterpy-qgis-plugin/issues
-repository=https://www.github.com/risegroup/clusterpy-qgis-plugin
+tracker=https://www.github.com/clusterpy/clusterpy-qgis-plugin/issues
+repository=https://www.github.com/clusterpy/clusterpy-qgis-plugin
 icon=uifiles/icon.png
 experimental=False
 

--- a/uifiles/about.html
+++ b/uifiles/about.html
@@ -37,7 +37,7 @@ url = {http://www.rise-group.org}
 <h3>About Clusterpy</h3>
 <p>This algorithm is part of a set of algorithms that can be found in the
 Clusterpy library for Python. <a href='http://www.rise-group.org/section/Software/clusterPy/'>Website</a>.
-Also on <a href='https://github.com/sergiobuj/clusterpy'>Github</a></p>
+Also on <a href='https://github.com/clusterpy/clusterpy'>Github</a></p>
 
 
 <h3>Contact and website</h3>

--- a/uifiles/maxphelp.html
+++ b/uifiles/maxphelp.html
@@ -33,5 +33,5 @@ centroid of its cluster.
 <h1>About Clusterpy</h1>
 <p>This algorithm is part of a set of algorithms that can be found in the
 Clusterpy library for Python. <a href='http://www.rise-group.org/section/Software/clusterPy/'>Website</a>.
-Also on <a href='https://github.com/sergiobuj/clusterpy'>Github</a></p>
+Also on <a href='https://github.com/clusterpy/clusterpy'>Github</a></p>
 


### PR DESCRIPTION
All the urls now point to the new home of the repository under the
clusterpy user on Github.
